### PR TITLE
Update version to 7.0.2, and rocm-core to mantainers and add rocm-core dependency

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -6,8 +6,6 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_name:
-- conda
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @isuruf
+* @conda-forge/rocm-core @isuruf

--- a/README.md
+++ b/README.md
@@ -117,12 +117,12 @@ it is possible to build and upload installable packages to the
 [conda-forge](https://anaconda.org/conda-forge) [anaconda.org](https://anaconda.org/)
 channel for Linux, Windows and OSX respectively.
 
-To manage the continuous integration and simplify feedstock maintenance
+To manage the continuous integration and simplify feedstock maintenance,
 [conda-smithy](https://github.com/conda-forge/conda-smithy) has been developed.
 Using the ``conda-forge.yml`` within this repository, it is possible to re-render all of
 this feedstock's supporting files (e.g. the CI configuration files) with ``conda smithy rerender``.
 
-For more information please check the [conda-forge documentation](https://conda-forge.org/docs/).
+For more information, please check the [conda-forge documentation](https://conda-forge.org/docs/).
 
 Terminology
 ===========
@@ -149,7 +149,7 @@ merged, the recipe will be re-built and uploaded automatically to the
 everybody to install and use from the `conda-forge` channel.
 Note that all branches in the conda-forge/rocm-cmake-feedstock are
 immediately built and any created packages are uploaded, so PRs should be based
-on branches in forks and branches in the main repository should only be used to
+on branches in forks, and branches in the main repository should only be used to
 build distinct package versions.
 
 In order to produce a uniquely identifiable distribution:
@@ -162,5 +162,6 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
+* [@conda-forge/rocm-core](https://github.com/orgs/conda-forge/teams/rocm-core/)
 * [@isuruf](https://github.com/isuruf/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "rocm-cmake" %}
-{% set version = "42" %}
+{% set version = "7.0.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/ROCm/rocm-cmake/archive/refs/tags/rocm-{{ version }}.tar.gz
-  sha256: 8b66717c1858f36a6f1581cb634c3ca37037ff4eb3588eb41cd5e6302dbaf1f2
+  sha256: 79c40408be17f7c73105e281154267fcc6851e1db8b6be01a411ef1d8050bc71
 
 build:
   number: 0
@@ -21,6 +21,7 @@ requirements:
     - cmake
     - make
   host:
+    - rocm-core {{ version }}
   run:
 
 test:
@@ -37,3 +38,4 @@ about:
 extra:
   recipe-maintainers:
     - isuruf
+    - conda-forge/rocm-core


### PR DESCRIPTION
This PR updates `rocm-cmake` to the latest version 7.0.1, adds the rocm-core dependency to act as a mutex package for rocm version in rocm packages (as discussed in https://github.com/conda-forge/rocm-core-feedstock/pull/4) and add `conda-forge/rocm-core` to the mantainers as done for other rocm repos in https://github.com/conda-forge/rocm-device-libs-feedstock/pull/21 .

Next step in updating HIP/ROCm packages to version 7.0.* as discussed in https://github.com/conda-forge/conda-forge.github.io/issues/1923#issuecomment-3324588344 .

fyi @isuruf @zklaus


<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
